### PR TITLE
Migrate to Gradle implementation

### DIFF
--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -28,5 +28,5 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
 }
 
 dependencies {
-    compile "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
 }


### PR DESCRIPTION
- Starting on Gradle 7.0 the compile method is removed.
- Trying to build an app making use of the compile method returns the following: > Could not find method compile() for arguments...
- This change migrates compile instances in the Gradle config file to use implementation instead